### PR TITLE
Suppress new Xcode 6.4 NSBSpritesheetLayer warning

### DIFF
--- a/NSBSpritesheetLayer/Classes/NSBSpritesheetLayer.m
+++ b/NSBSpritesheetLayer/Classes/NSBSpritesheetLayer.m
@@ -35,6 +35,8 @@
 
 @implementation NSBSpritesheetLayer
 
+@dynamic autoreverses; // Implemented by CALayer.
+
 - (instancetype)initWithSpritesheet:(NSBSpritesheet *)spritesheet framesPerSecond:(NSUInteger)framesPerSecond
 {
     NSParameterAssert(spritesheet);


### PR DESCRIPTION
Xcode 6.4 emits a new warning:

```
NSBSpritesheetLayer/Classes/NSBSpritesheetLayer.h:32:47: Auto property synthesis will not synthesize property 'autoreverses'; it will be implemented by its superclass, use @dynamic to acknowledge intention
```

It's true: `CALayer` implements the setter and getter, and we don't intend to replace those implementations.
